### PR TITLE
Decrease epsilon when discounting rewards in PPO.

### DIFF
--- a/Policy Gradient/src/PPO/PPO.py
+++ b/Policy Gradient/src/PPO/PPO.py
@@ -41,7 +41,7 @@ class PPO:
 
     # normalise rewards
     discounted_returns = torch.FloatTensor(discounted_returns).to(device)
-    discounted_returns = (discounted_returns - discounted_returns.mean()) / (discounted_returns.std() + 1e-5)
+    discounted_returns = (discounted_returns - discounted_returns.mean()) / (discounted_returns.std() + 1e-8)
 
     prev_states = torch.stack(self.mem.states).to(device).detach()
     prev_actions = torch.stack(self.mem.actions).to(device).detach()
@@ -102,7 +102,7 @@ class PPOContinuous(PPO):
 
     # normalise rewards
     discounted_returns = torch.FloatTensor(discounted_returns).to(device)
-    discounted_returns = (discounted_returns - discounted_returns.mean()) / (discounted_returns.std() + 1e-5)
+    discounted_returns = (discounted_returns - discounted_returns.mean()) / (discounted_returns.std() + 1e-8)
 
     
 


### PR DESCRIPTION
What do you think about this. A minor thing really but if you check what Andy [shared](https://twitter.com/araffin2/status/1329382226421837825) recently this could be important. Usually those epsilon values are in the range 1e-7 to 1e-11 or the likes.